### PR TITLE
Utf fix

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -147,7 +147,7 @@ int main(int argc, const char **argv) {
     int ret;
     while(RUNNING) {
         if((ret = handle_keys())  || REDRAW) {
-            assert(ret != -1 && "bad keys");
+            assert(ret >= 0 && "bad keys");
             REDRAW = 0;
             editor_render(&WS);
         }

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <sys/termios.h>
 #include <string.h>
+#include <assert.h>
 
 #include "config.h"
 #include "termkey.h"
@@ -143,8 +144,10 @@ int main(int argc, const char **argv) {
     editor_init();
 
     editor_render(&WS);
+    int ret;
     while(RUNNING) {
-        if(handle_keys() || REDRAW) {
+        if((ret = handle_keys())  || REDRAW) {
+            assert(ret != -1 && "bad keys");
             REDRAW = 0;
             editor_render(&WS);
         }

--- a/src/str.c
+++ b/src/str.c
@@ -452,6 +452,11 @@ TEST_DEF(test_str_tail_len)
     ASSERT(str_len(&b) == 5);
 TEST_ENDDEF
 
+TEST_DEF(test_str_len)
+    Str s = str_from_cstr("ア");
+    ASSERT(str_len(&s) == 1);
+TEST_ENDDEF
+
 TESTS_END
 
 #endif

--- a/src/termkey.c
+++ b/src/termkey.c
@@ -8,6 +8,8 @@
 #include <limits.h>
 #include <ctype.h>
 
+#include <assert.h>
+
 #include "utf.h"
 
 // Attempts to read an unsigned int from fd
@@ -40,13 +42,13 @@ static int read_utf8(int fd, char (*out)[4], int count) {
     char c;
     for(int i = 1; i < count; i++) {
         ret = read(fd, &c, 1);
+        assert(c != 0 && "null byte in stream");
         if(ret == -1) return -1;
         // missing a byte
         if(ret == 0) return -2;
         // the next byte is invalid
         if(!utf8_is_follow(c)) return -2;
         (*out)[i] = c;
-        i+= 1;
     }
     return 0;
 }

--- a/src/utf.c
+++ b/src/utf.c
@@ -145,8 +145,7 @@ int utf32_width(utf32 c) {
         switch(wc) {
             case L'\t':
                 return CONFIG.tab_width;
-            default: {}
-                //assert(0 && "unknown variant");
+            default: assert(0 && "unknown variant");
         }
     }
     return width;


### PR DESCRIPTION
Added tests and fixed a bug in the utf8 reading function when reading from the terminal, for some reason, the bug only showed up when copy and pasting.